### PR TITLE
Implement domain verification for Bluesky

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minifolio",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minifolio",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minifolio",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "private": true,
   "license": "GPL-3.0-only",
   "scripts": {

--- a/src/lib/server/data/config.ts
+++ b/src/lib/server/data/config.ts
@@ -1,8 +1,9 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { array, nullable, object, string, validate, type Infer } from 'superstruct';
+import { nullable, object, string, validate, type Infer } from 'superstruct';
 import { getDataDir } from './dataDir';
 import { version } from '$app/environment';
 import { unsafeLoadConfig } from './migrations/unsafeLoad';
+import { IdVerificationStruct } from './idVerification';
 
 /** Path to config.json */
 const CONFIG_JSON = () => `${getDataDir()}/config.json`;
@@ -11,8 +12,8 @@ const CONFIG_JSON = () => `${getDataDir()}/config.json`;
 export const ConfigJsonStruct = object({
   /** Filename of icon to use for the site */
   siteIcon: nullable(string()),
-  /** Links to place in `<link rel="me" href="{}">` fields */
-  relMe: array(string()),
+  /** Identity verification */
+  verification: IdVerificationStruct,
   /** Version of server that last accessed the config.json */
   version: string(),
 });
@@ -57,7 +58,10 @@ export async function setConfig(newConfig: ConfigJson) {
 export async function initConfig() {
   await setConfig({
     siteIcon: null,
-    relMe: [],
+    verification: {
+      relMe: [],
+      atProtocol: null
+    },
     version,
   });
 }

--- a/src/lib/server/data/idVerification.ts
+++ b/src/lib/server/data/idVerification.ts
@@ -1,0 +1,16 @@
+import { array, nullable, object, string } from 'superstruct';
+
+export const IdVerificationStruct = object({
+  /**
+   * rel="me" verification, used by Mastodon, GitHub and Wikipedia.
+   *
+   * Links to place in `<link rel="me" href="{}">` fields.
+   */
+  relMe: array(string()),
+  /**
+   * AT-Protocol decentralized ID, used by Bluesky.
+   *
+   * ID is returned by the `/.well-known/atproto-did` endpoint
+   */
+  atProtocol: nullable(string()),
+});

--- a/src/lib/server/data/idVerification.ts
+++ b/src/lib/server/data/idVerification.ts
@@ -10,6 +10,8 @@ export const IdVerificationStruct = object({
   /**
    * AT-Protocol decentralized ID, used by Bluesky.
    *
+   * Due to the design of their verification system, only one account can be verified per domain.
+   *
    * ID is returned by the `/.well-known/atproto-did` endpoint
    */
   atProtocol: nullable(string()),

--- a/src/lib/server/data/migrations/index.ts
+++ b/src/lib/server/data/migrations/index.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 import consts from '$lib/consts';
 import path from 'node:path';
 import { migrateDataV06, migratePrivateV06 } from './v0.6';
+import { migrateDataV10, migratePrivateV10 } from './v1.0';
 import { getDataVersion, getPrivateDataVersion, bumpDataVersion, bumpPrivateDataVersion } from './shared';
 import { tmpdir } from 'node:os';
 
@@ -19,16 +20,22 @@ export type PrivateMigrationFunction = (
 
 // Migrations for data
 const dataMigrations: Record<string, DataMigrationFunction> = {
-  // v0.6.x --> v1.0.0
+  // v0.6.x --> v1.1.0
   '~0.6.1': migrateDataV06,
-  '~1.0.0': bumpDataVersion,
+  // v1.0.x --> v1.1.0
+  '~1.0.0': migrateDataV10,
+  // v1.1.x (minor version bumps)
+  '~1.1.0': bumpDataVersion,
 };
 
 // Migrations for private data
 const privateMigrations: Record<string, PrivateMigrationFunction> = {
-  // v0.6.x --> v1.0.0
+  // v0.6.x --> v1.1.0
   '~0.6.1': migratePrivateV06,
-  '~1.0.0': bumpPrivateDataVersion,
+  // v1.0.x --> v1.1.0
+  '~1.0.0': migratePrivateV10,
+  // v1.1.x (minor version bumps)
+  '~1.1.0': bumpPrivateDataVersion,
 };
 
 /** Perform a migration from the given version */

--- a/src/lib/server/data/migrations/v0.6.ts
+++ b/src/lib/server/data/migrations/v0.6.ts
@@ -78,7 +78,10 @@ async function updatePublicConfig(dataDir: string) {
   const oldConfig: any = await unsafeLoadConfig(dataDir);
   await setConfig({
     version,
-    relMe: [],
+    verification: {
+      relMe: [],
+      atProtocol: null,
+    },
     siteIcon: oldConfig.siteIcon,
   });
 }

--- a/src/lib/server/data/migrations/v1.0.ts
+++ b/src/lib/server/data/migrations/v1.0.ts
@@ -1,0 +1,28 @@
+import { version } from '$app/environment';
+import { setConfig } from '../config';
+import { bumpPrivateDataVersion } from './shared';
+import { unsafeLoadConfig } from './unsafeLoad';
+
+export async function migratePrivateV10(privateDataDir: string) {
+  // Update `config.local.json`
+  console.log('config.local.json');
+  await bumpPrivateDataVersion(privateDataDir);
+}
+
+export async function migrateDataV10(dataDir: string) {
+  console.log('config.json');
+  await updatePublicConfig(dataDir);
+}
+
+/** Update `config.json` */
+async function updatePublicConfig(dataDir: string) {
+  const oldConfig: any = await unsafeLoadConfig(dataDir);
+  await setConfig({
+    version,
+    verification: {
+      relMe: oldConfig.relMe,
+      atProtocol: null,
+    },
+    siteIcon: oldConfig.siteIcon,
+  });
+}

--- a/src/routes/[...item]/+page.svelte
+++ b/src/routes/[...item]/+page.svelte
@@ -88,7 +88,7 @@
   />
   <meta name="theme-color" content={data.item.info.color} />
   <Favicon path={data.config.siteIcon ?? undefined} />
-  {#each data.config.relMe as me}
+  {#each data.config.verification.relMe as me}
     <link rel="me" href={me} />
   {/each}
 </svelte:head>

--- a/src/routes/admin/PublicConfig.svelte
+++ b/src/routes/admin/PublicConfig.svelte
@@ -51,15 +51,15 @@
 
     <label for="rel-me"><h3>Verification links</h3></label>
     <TextArea
-      bind:value={() => config.relMe.join('\n'),
-      (relMe: string) => (config.relMe = relMe.trim().split('\n'))}
+      bind:value={() => config.verification.relMe.join('\n'),
+      (relMe: string) => (config.verification.relMe = relMe.trim().split('\n'))}
       oninput={() => updater.update(config)}
     />
     <p>Place each URL on a separate line.</p>
     <p>The links will be included as:</p>
     <CodeBlock
       language="html"
-      code={config.relMe
+      code={config.verification.relMe
         .map((me) => `<link rel="me" href="${me}" />`)
         .join('\n')}
     />

--- a/tests/backend/config/get.test.ts
+++ b/tests/backend/config/get.test.ts
@@ -17,7 +17,10 @@ beforeEach(async () => {
 it('Returns the current config contents', async () => {
   await expect(api.config.get()).resolves.toStrictEqual({
     siteIcon: null,
-    relMe: [],
+    verification: {
+      relMe: [],
+      atProtocol: null,
+    },
     version,
   });
 });

--- a/tests/backend/helpers.ts
+++ b/tests/backend/helpers.ts
@@ -25,7 +25,10 @@ export async function setup(repoUrl?: string, branch?: string) {
 export function makeConfig(options: Partial<ConfigJson> = {}): ConfigJson {
   const config: ConfigJson = {
     siteIcon: null,
-    relMe: [],
+    verification: {
+      relMe: [],
+      atProtocol: null,
+    },
     version,
   };
   return { ...config, ...options };


### PR DESCRIPTION
* This PR moves the `relMe` array within `config.json` to a `verification` object, where other site verification protocols can also be stored.
* It adds a section to `verification` named `atProtocol` for verification of Bluesky accounts (and other platforms using the AT Protocol).

Todos:

- [x] Add new data to `config.json`
- [x] Add data migrations
- [ ] Test it
- [ ] Implement on front-end