### PR TITLE
Add /api/health healthcheck route

### DIFF
--- a/docker/production.dockerfile
+++ b/docker/production.dockerfile
@@ -1,4 +1,4 @@
-# docker/staging.dockerfile
+# docker/production.dockerfile
 # =====================
 #
 # Dockerfile for running the server in production mode.
@@ -40,4 +40,5 @@ RUN npm run build
 
 EXPOSE 3000
 
-ENTRYPOINT [ "node", "-r", "dotenv/config", "build" ]
+HEALTHCHECK CMD ["curl", "-f", "http://127.0.0.1:3000/api/health"]
+ENTRYPOINT [ "node", "build" ]

--- a/src/endpoints/fetch/ApiError.ts
+++ b/src/endpoints/fetch/ApiError.ts
@@ -6,17 +6,20 @@ class ApiError extends Error {
   error: string;
   /** Status code */
   code: number | null;
+  /** Body (if JSON, it is parsed) */
+  body: object | string | null;
 
   /**
    * Custom error class for errors that happen when fetching data
    */
-  constructor(code: number | null, error: string | object) {
+  constructor(code: number | null, error: string | object, body: string | object | null) {
     if (typeof error === 'object') {
       error = JSON.stringify(error);
     }
     super(`ApiError: [${code}] ${error}`);
     this.error = error;
     this.code = code;
+    this.body = body;
   }
 }
 

--- a/src/endpoints/fetch/fetch.ts
+++ b/src/endpoints/fetch/fetch.ts
@@ -6,7 +6,11 @@ import type { PayloadInfo } from './payload';
 export type HttpVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 if (!browser) {
-  process.loadEnvFile('.env');
+  try {
+    process.loadEnvFile('.env');
+  } catch (e) {
+    console.log('Could not load .env file. Default host and port will be used.');
+  }
 }
 
 /**
@@ -85,9 +89,9 @@ export function apiFetch(
   } catch (err) {
     // Likely a network issue
     if (err instanceof Error) {
-      throw new ApiError(null, err.message);
+      throw new ApiError(null, err.message, null);
     } else {
-      throw new ApiError(null, `Unknown request error ${err}`);
+      throw new ApiError(null, `Unknown request error ${err}`, null);
     }
   }
 }

--- a/src/endpoints/fetch/response.ts
+++ b/src/endpoints/fetch/response.ts
@@ -1,18 +1,26 @@
 import ApiError from './ApiError';
 
+function tryJson(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 /** Process a text response, returning the text as a string */
 export async function text(response: Promise<Response>): Promise<string> {
   const res = await response;
   if ([404, 405].includes(res.status)) {
-    throw new ApiError(404, `Error ${res.status} at ${res.url}`);
+    throw new ApiError(404, `Error ${res.status} at ${res.url}`, tryJson(await res.text()));
   }
   const text = await res.text();
   if ([400, 401, 403].includes(res.status)) {
-    throw new ApiError(res.status, text);
+    throw new ApiError(res.status, text, tryJson(text));
   }
   if (![200, 304].includes(res.status)) {
     // Unknown error
-    throw new ApiError(res.status, `Request got status code ${res.status}`);
+    throw new ApiError(res.status, `Request got status code ${res.status}`, tryJson(text));
   }
   return text;
 }
@@ -22,15 +30,15 @@ export async function xml(response: Promise<Response>): Promise<object> {
   // TODO: Fix this coed duplication
   const res = await response;
   if ([404, 405].includes(res.status)) {
-    throw new ApiError(404, `Error ${res.status} at ${res.url}`);
+    throw new ApiError(404, `Error ${res.status} at ${res.url}`, tryJson(await res.text()));
   }
   const text = await res.text();
   if ([400, 401, 403].includes(res.status)) {
-    throw new ApiError(res.status, text);
+    throw new ApiError(res.status, text, tryJson(text));
   }
   if (![200, 304].includes(res.status)) {
     // Unknown error
-    throw new ApiError(res.status, `Request got status code ${res.status}`);
+    throw new ApiError(res.status, `Request got status code ${res.status}`, tryJson(text));
   }
 
   // Import dynamically, to avoid front-end glitches.
@@ -43,37 +51,35 @@ export async function xml(response: Promise<Response>): Promise<object> {
 export async function json(response: Promise<Response>): Promise<object> {
   const res = await response;
   if ([404, 405].includes(res.status)) {
-    throw new ApiError(404, `Error ${res.status} at ${res.url}`);
+    throw new ApiError(404, `Error ${res.status} at ${res.url}`, tryJson(await res.text()));
   }
   if (res.status >= 500) {
     // Unknown error
-    throw new ApiError(res.status, `Request got status code ${res.status}`);
+    throw new ApiError(res.status, `Request got status code ${res.status}`, tryJson(await res.text()));
   }
   // Decode the data
-  // const text = await res.text();
-  // console.log(text);
+  const text = await res.text();
   let json: object;
   try {
-    json = await res.json();
-    // json = JSON.parse(text);
+    json = JSON.parse(text);
   } catch (err) {
     // JSON parse error
     if (err instanceof Error) {
-      throw new ApiError(null, err.message);
+      throw new ApiError(null, err.message, tryJson(text));
     } else {
-      throw new ApiError(null, `Unknown JSON error ${err}`);
+      throw new ApiError(null, `Unknown JSON error ${err}`, tryJson(text));
     }
   }
 
   if ([400, 401, 403].includes(res.status)) {
     // All 400, 401 and 403 errors have an error message
     const message = (json as { message: string }).message;
-    throw new ApiError(res.status, message);
+    throw new ApiError(res.status, message, tryJson(text));
   }
 
   // Got valid data
   // Assign it to a new object, because otherwise it'll fail to match using
-  // `.toStrictEqual`, likely due to some weirdness with Jest
+  // `.toStrictEqual`, likely due to some weirdness with Jest.
   // Seems to be similar to the issues described at these URLs
   // https://github.com/jestjs/jest/issues/8446
   // https://github.com/nktnet1/jewire?tab=readme-ov-file#53-rewire-and-jest
@@ -84,15 +90,15 @@ export async function json(response: Promise<Response>): Promise<object> {
 export async function buffer(response: Promise<Response>): Promise<Uint8Array> {
   const res = await response;
   if ([404, 405].includes(res.status)) {
-    throw new ApiError(404, `Error ${res.status} at ${res.url}`);
+    throw new ApiError(404, `Error ${res.status} at ${res.url}`, tryJson(await res.text()));
   }
   const buf = await res.bytes();
   if ([400, 401, 403].includes(res.status)) {
-    throw new ApiError(res.status, buf);
+    throw new ApiError(res.status, buf, tryJson(await res.text()));
   }
   if (![200, 304].includes(res.status)) {
     // Unknown error
-    throw new ApiError(res.status, `Request got status code ${res.status}`);
+    throw new ApiError(res.status, `Request got status code ${res.status}`, tryJson(await res.text()));
   }
   return buf;
 }

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,5 +1,6 @@
 /** API endpoints */
 import type { ItemId } from '$lib/itemId';
+import type { HealthcheckResponse } from '../routes/api/health/+server';
 import admin from './admin';
 import config from './config';
 import debug from './debug';
@@ -10,6 +11,10 @@ import robotsTxt from './robots.txt';
 
 export function sitemap(fetchFn: typeof fetch, token: string | undefined) {
   return apiFetch(fetchFn, 'GET', '/sitemap.xml', { token }).xml();
+}
+
+export function health(fetchFn: typeof fetch, token: string | undefined) {
+  return apiFetch(fetchFn, 'GET', '/api/health', { token }).json() as Promise<HealthcheckResponse>;
 }
 
 /** Create an instance of the API client with the given token */
@@ -25,6 +30,8 @@ export default function api(fetchFn: typeof fetch = fetch, token?: string) {
     item: (itemId: ItemId) => item(fetchFn, token, itemId),
     /** Sitemap.xml, converted to JS object */
     sitemap: () => sitemap(fetchFn, token),
+    /** Healthcheck */
+    health: () => health(fetchFn, token),
     /** robots.txt file */
     robots: robotsTxt(fetchFn, token),
     /** An HTML page */

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -13,7 +13,13 @@ export const handle = sequence(...middleware);
 
 /** Called when the server starts */
 async function onStartup() {
-  await migrateAll();
+  try {
+    await migrateAll();
+  } catch (e) {
+    console.error('Error in startup hooks!');
+    console.error(e);
+    return;
+  }
 }
 
 void onStartup();

--- a/src/middleware/bans.ts
+++ b/src/middleware/bans.ts
@@ -1,5 +1,5 @@
 import { authIsSetUp } from '$lib/server/data/dataDir';
-import { getLocalConfig } from '$lib/server/data/localConfig';
+import { ConfigLocalJson, getLocalConfig } from '$lib/server/data/localConfig';
 import { getIpFromRequest } from '$lib/server/request';
 import { error, type Handle } from '@sveltejs/kit';
 
@@ -12,7 +12,14 @@ const banMiddleware: Handle = async (req) => {
   ) {
     return req.resolve(req.event);
   }
-  const config = await getLocalConfig();
+  let config: ConfigLocalJson;
+  try {
+    config = await getLocalConfig();
+  } catch (e) {
+    console.error('Error in ban middleware!');
+    console.error(e);
+    return req.resolve(req.event);
+  }
   const ip = await getIpFromRequest(req.event);
   if (config.bannedIps.includes(ip)) {
     error(403, 'This IP address is banned');

--- a/src/routes/api/health/+server.ts
+++ b/src/routes/api/health/+server.ts
@@ -1,0 +1,40 @@
+/**
+ * POST /api/health
+ *
+ * Perform basic checks to ensure the server is healthy.
+ */
+import itemId from '$lib/itemId';
+import { getConfig } from '$lib/server/data/config';
+import { authIsSetUp, dataIsSetUp } from '$lib/server/data/dataDir';
+import { getItemData } from '$lib/server/data/item';
+import { getLocalConfig } from '$lib/server/data/localConfig';
+import { json } from '@sveltejs/kit';
+
+export async function GET() {
+  let localConfigOk = null;
+  if (await authIsSetUp()) {
+    localConfigOk = await getLocalConfig().then(() => true).catch(() => false);
+  }
+
+  let configOk = null;
+  let dataOk = null;
+
+  if (await dataIsSetUp()) {
+    configOk = await getConfig().then(() => true).catch(() => false);
+    dataOk = await getItemData(itemId.ROOT).then(() => true).catch(() => false);
+  }
+
+  const healthy = localConfigOk !== false && dataOk !== false && configOk !== false;
+
+  return json(
+    { healthy, localConfigOk, configOk, dataOk } satisfies HealthcheckResponse,
+    { status: healthy ? 200 : 500 },
+  );
+}
+
+export type HealthcheckResponse = {
+  healthy: boolean,
+  localConfigOk: boolean | null,
+  configOk: boolean | null,
+  dataOk: boolean | null,
+};

--- a/tests/backend/health.test.ts
+++ b/tests/backend/health.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Test cases for /api/health
+ */
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import type { ApiClient } from '$endpoints';
+import { beforeEach, expect, it } from 'vitest';
+import { setup } from './helpers';
+import { getDataDir, getPrivateDataDir } from '$lib/server/data/dataDir';
+
+let api: ApiClient;
+beforeEach(async () => {
+  api = (await setup()).api;
+});
+
+it('is healthy after being set up', async () => {
+  await expect(api.health()).resolves.toStrictEqual({
+    healthy: true,
+    configOk: true,
+    dataOk: true,
+    localConfigOk: true,
+  });
+});
+
+it('is healthy after clearing data', async () => {
+  await api.debug.clear();
+  await expect(api.health()).resolves.toStrictEqual({
+    healthy: true,
+    configOk: null,
+    dataOk: null,
+    localConfigOk: null,
+  });
+});
+
+it('is unhealthy after corrupting local config', async () => {
+  const f = path.join(getPrivateDataDir(), 'config.local.json');
+  await fs.writeFile(f, 'corrupt');
+  await expect(api.health()).rejects.toMatchObject({
+    code: 500,
+    body: {
+      healthy: false,
+      configOk: true,
+      dataOk: true,
+      localConfigOk: false,
+    },
+  });
+});
+
+it('is unhealthy after corrupting config', async () => {
+  const f = path.join(getDataDir(), 'config.json');
+  await fs.writeFile(f, 'corrupt');
+  await expect(api.health()).rejects.toMatchObject({
+    code: 500,
+    body: {
+      healthy: false,
+      configOk: false,
+      dataOk: true,
+      localConfigOk: true,
+    },
+  });
+});
+
+it('is unhealthy after corrupting data', async () => {
+  const f = path.join(getDataDir(), 'info.json');
+  await fs.writeFile(f, 'corrupt');
+  await expect(api.health()).rejects.toMatchObject({
+    code: 500,
+    body: {
+      healthy: false,
+      configOk: true,
+      dataOk: false,
+      localConfigOk: true,
+    },
+  });
+});

--- a/tests/setup/globalSetup.ts
+++ b/tests/setup/globalSetup.ts
@@ -2,7 +2,11 @@ import { ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import api from '$endpoints';
 
-process.loadEnvFile('.env');
+try {
+  process.loadEnvFile('.env');
+} catch (e) {
+  console.log('Could not load .env file. Default host and port will be used.');
+}
 
 let server: ChildProcess | undefined;
 


### PR DESCRIPTION
* `GET /api/health` checks basic validity of data
* This is configured for use in Docker.
* Also fixes the invalid commands for starting up the server in docker

Resolves #351