### PR TITLE
npm and github actions: increase minimum dependency release age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 3
+      default-days: 7
     groups:
       marked:
         applies-to: version-updates
@@ -59,4 +59,4 @@ updates:
     schedule:
       interval: "monthly"
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=7


### PR DESCRIPTION
You can never be too careful